### PR TITLE
Added HTML to obs

### DIFF
--- a/core/src/browsergym/core/env.py
+++ b/core/src/browsergym/core/env.py
@@ -399,6 +399,7 @@ document.addEventListener("visibilitychange", () => {
             "open_pages_urls": [page.url for page in self.context.pages],
             "active_page_index": np.asarray([self.context.pages.index(self.page)]),
             "url": self.page.url,
+            "html": self.page.content(),
             "screenshot": extract_screenshot(self.page),
             "dom_object": dom,
             "axtree_object": axtree,


### PR DESCRIPTION
LaVague (lavague-ai/LaVague: Copilot for web automation) works on the raw HTML provided by the browser for now.

Adding that to the set of observables.