### PR TITLE
Pass just args, not kwargs to gymnasium, and setup start_url correctly

### DIFF
--- a/core/src/browsergym/core/env.py
+++ b/core/src/browsergym/core/env.py
@@ -148,7 +148,7 @@ class BrowserEnv(gym.Env, ABC):
             self.task = None
 
     def reset(self, seed=None, *args, **kwargs):
-        super().reset(seed=seed, *args, **kwargs)
+        super().reset(seed=seed, *args)
         self.np_random = None  # make sure all randomness is handled by the task
 
         if self.task:

--- a/core/src/browsergym/core/task.py
+++ b/core/src/browsergym/core/task.py
@@ -78,7 +78,7 @@ class OpenEndedTask(AbstractBrowserTask):
     def get_task_id(cls):
         return "openended"
 
-    def __init__(self, seed: int, start_url: str, goal: str = None) -> None:
+    def __init__(self, seed: int, start_url: str = 'about:blank', goal: str = None) -> None:
         """
         Args:
             seed: random seed.


### PR DESCRIPTION
The reset definition in gymnasium only accepts args, not kwargs. See https://github.com/Farama-Foundation/Gymnasium/blob/main/gymnasium/core.py#L113.

```python3
    def reset(
        self,
        *,
        seed: int | None = None,
        options: dict[str, Any] | None = None,
    ) -> tuple[ObsType, dict[str, Any]]:  # type: ignore
```

This is related to https://github.com/OpenDevin/OpenDevin/issues/1747
