### PR TITLE
Add self-consistency and AzureOpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ python run_demo.py --task_name openended --start_url https://www.google.com
 
 You can customize your experience by changing the `model_name` to your preferred LLM, toggling Chain-of-thought with `use_thinking`, adding screenshots for your VLMs with `use_screenshot`, and much more!
 
+To use AzureOpenAI within the demo, set the following environment variables:
+```sh
+export AZURE_OPENAI_API_KEY="<YOUR_API_KEY>"
+export AZURE_OPENAI_ENDPOINT="https://<YOUR_SUBSCRIPTION_NAME>.openai.azure.com"
+export AZURE_OPENAI_API_VERSION="<API_VERSION>"
+export AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="<DEPLOYMENT_NAME>"
+```
 
 ## Citing This Work
 

--- a/demo_agent/agents/legacy/dynamic_prompting.py
+++ b/demo_agent/agents/legacy/dynamic_prompting.py
@@ -37,6 +37,7 @@ class Flags:
     use_action_history: bool = False
     use_memory: bool = False
     use_diff: bool = False
+    use_self_consistency: bool = False
     html_type: str = "pruned_html"
     use_concrete_example: bool = True
     use_abstract_example: bool = False

--- a/demo_agent/agents/legacy/utils/chat_api.py
+++ b/demo_agent/agents/legacy/utils/chat_api.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict, dataclass
+import os
 import io
 import json
 from .prompt_templates import PromptTemplate, get_prompt_template
@@ -10,7 +11,7 @@ from typing import Tuple
 import time
 
 from langchain_community.llms import HuggingFaceHub, HuggingFacePipeline
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, AzureChatOpenAI
 from langchain.schema import BaseMessage
 from langchain.chat_models.base import SimpleChatModel
 from langchain.callbacks.manager import CallbackManagerForLLMRun
@@ -78,6 +79,19 @@ class ChatModelArgs:
             _, model_name = self.model_name.split("/")
             return ChatOpenAI(
                 model_name=model_name,
+                temperature=self.temperature,
+                max_tokens=self.max_new_tokens,
+            )
+        elif self.model_name.startswith("azure"):
+            # Set the model name as follows: azure/gpt-3.5-turbo, azure/gpt-4-turbo
+            # Where "gpt-3.5-turbo" is the model name on OpenAI Platform
+            # Required to match the right model on tiktoken
+            # Azure model name is defined using ENV variable `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME`
+            return AzureChatOpenAI(
+                api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
+                azure_deployment=os.getenv(
+                    "AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"
+                ),
                 temperature=self.temperature,
                 max_tokens=self.max_new_tokens,
             )

--- a/demo_agent/agents/legacy/utils/llm_utils.py
+++ b/demo_agent/agents/legacy/utils/llm_utils.py
@@ -174,7 +174,7 @@ def truncate_tokens(text, max_tokens=8000, start=0, model_name="gpt-4"):
 
 @cache
 def get_tokenizer(model_name="openai/gpt-4"):
-    if model_name.startswith("openai"):
+    if model_name.startswith("openai") or model_name.startswith("azure"):
         return tiktoken.encoding_for_model(model_name.split("/")[-1])
     else:
         return AutoTokenizer.from_pretrained(model_name)

--- a/demo_agent/run_demo.py
+++ b/demo_agent/run_demo.py
@@ -95,6 +95,18 @@ def parse_args():
         default=True,
         help="Use thinking in the agent (chain-of-thought prompting).",
     )
+    parser.add_argument(
+        "--use_self_consistency",
+        type=str2bool,
+        default=False,
+        help="Use self-consistency in the agent's observation space.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.1,
+        help="Temperature for the chat model (higher values are more creative).",
+    )
 
     return parser.parse_args()
 
@@ -125,6 +137,7 @@ WARNING this demo agent will soon be moved elsewhere. Expect it to be removed at
         agent_args=GenericAgentArgs(
             chat_model_args=ChatModelArgs(
                 model_name=args.model_name,
+                temperature=args.temperature,
                 max_total_tokens=128_000,  # "Maximum total tokens for the chat model."
                 max_input_tokens=126_000,  # "Maximum tokens for the input to the chat model."
                 max_new_tokens=2_000,  # "Maximum total tokens for the chat model."
@@ -137,6 +150,7 @@ WARNING this demo agent will soon be moved elsewhere. Expect it to be removed at
                 use_memory=False,  # "Enables the agent with a memory (scratchpad)."
                 use_history=args.use_history,
                 use_diff=False,  # "Prompt the agent with the difference between the current and past observation."
+                use_self_consistency=args.use_self_consistency,  # "Prompt the agent with the self-consistency."
                 use_past_error_logs=True,  # "Prompt the agent with the past error logs."
                 use_action_history=True,  # "Prompt the agent with the action history."
                 multi_actions=args.multi_actions,


### PR DESCRIPTION
In this PR I suugest adding:

- AzureOpenAI API for ChatModels.
- A naive implementation of self-consistency from [this paper](https://arxiv.org/abs/2203.11171). The idea is to sample different answers by setting the temperature to a higher value and calling the model multiple times, then choosing the most consistent answer. In this case, we choose the action that is predicted the most commonly.

**Note:** I may have missed something during the implementation of self-consistency, because I don't understand exactly how the `GenericAgent` works. This implementation considers that the model outputs 1 action at a time and not multiple ones.