### PR TITLE
switched screenshot from a property to a method

### DIFF
--- a/experiments/src/browsergym/experiments/loop.py
+++ b/experiments/src/browsergym/experiments/loop.py
@@ -531,7 +531,6 @@ class ExpResult:
             self._screenshots[key] = Image.open(self.exp_dir / file_name)
         return self._screenshots[key]
 
-    @property
     def screenshots(self, som=False):
         files = list(self.exp_dir.glob("screenshot_step_*.jpg"))
         for file in files:


### PR DESCRIPTION
Args cannot be passed to a property. This has 1 dependencies in Browsergym (that wouldnt work), and one in agentlab (agent_xray) that breaks with this fix.