### PR TITLE
Better AXTree / bid marking

### DIFF
--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -491,7 +491,7 @@ document.addEventListener("visibilitychange", () => {
                     logger.warning(
                         f"An error occured while extracting the dom and axtree. Retrying ({retries_left}/{EXTRACT_OBS_MAX_TRIES} tries left).\n{repr(e)}"
                     )
-                    # post-extract cleanup (aria-roledescription attribute)
+                    # post-extract cleanup (ARIA attributes)
                     _post_extract(self.page)
                     time.sleep(0.5)
                     continue

--- a/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
+++ b/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
@@ -1,6 +1,6 @@
 /**
  * Go through all DOM elements in the frame (including shadowDOMs), give them unique browsergym
- * identifiers (bid), and store custom data in the aria-roledescription attribute.
+ * identifiers (bid), and store custom data in ARIA attributes.
  */
 async ([parent_bid, bid_attr_name]) => {
 
@@ -132,15 +132,11 @@ async ([parent_bid, bid_attr_name]) => {
         }
         all_bids.add(elem_global_bid);
 
-        // Hack: store custom data inside the aria-roledescription attribute (will be available in DOM and AXTree)
+        // Hack: store custom data inside ARIA attributes (will be available in DOM and AXTree)
         //  - elem_global_bid: global element identifier (unique over multiple frames)
         // TODO: add more data if needed (x, y coordinates, bounding box, is_visible, is_clickable etc.)
-        let original_content = "";
-        if (elem.hasAttribute("aria-roledescription")) {
-            original_content = elem.getAttribute("aria-roledescription");
-        }
-        let new_content = `${elem_global_bid}_${original_content}`
-        elem.setAttribute("aria-roledescription", new_content);
+        push_bid_to_attribute(elem_global_bid, elem, "aria-roledescription");
+        push_bid_to_attribute(elem_global_bid, elem, "aria-description");  // fallback for generic nodes
 
         // set-of-marks flag (He et al. 2024)
         // https://github.com/MinorJerry/WebVoyager/blob/main/utils.py
@@ -227,6 +223,15 @@ function whoCapturesCenterClick(element){
     } else {
         return "non-descendant";
     }
+}
+
+function push_bid_to_attribute(bid, elem, attr){
+    let original_content = "";
+    if (elem.hasAttribute(attr)) {
+        original_content = elem.getAttribute(attr);
+    }
+    let new_content = `browsergym_id_${bid} ${original_content}`
+    elem.setAttribute(attr, new_content);
 }
 
 function elementFromPoint(x, y) {

--- a/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
+++ b/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
@@ -3,24 +3,6 @@
  * identifiers (bid), and store custom data in ARIA attributes.
  */
 async ([parent_bid, bid_attr_name]) => {
-
-    // standard html tags
-    // https://www.w3schools.com/tags/
-    const html_tags = new Set([
-        "a", "abbr", "acronym", "address", "applet", "area", "article", "aside", "audio",
-        "b", "base", "basefont", "bdi", "bdo", "big", "blockquote", "body", "br", "button",
-        "canvas", "caption", "center", "cite", "code", "col", "colgroup", "data", "datalist",
-        "dd", "del", "details", "dfn", "dialog", "dir", "div", "dl", "dt", "em", "embed",
-        "fieldset", "figcaption", "figure", "font", "footer", "form", "frame", "frameset",
-        "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr", "html", "i",
-        "iframe", "img", "input", "ins", "kbd", "label", "legend", "li", "link", "main",
-        "map", "mark", "menu", "meta", "meter", "nav", "noframes", "noscript", "object",
-        "ol", "optgroup", "option", "output", "p", "param", "picture", "pre", "progress",
-        "q", "rp", "rt", "ruby", "s", "samp", "script", "search", "section", "select",
-        "small", "source", "span", "strike", "strong", "style", "sub", "summary", "sup",
-        "svg", "table", "tbody", "td", "template", "textarea", "tfoot", "th", "thead",
-        "time", "title", "tr", "track", "tt", "u", "ul", "var", "video", "wbr"
-    ]);
     const set_of_marks_tags = new Set([
         "input", "textarea", "select", "button", "a", "iframe", "video", "li", "td", "option"
     ]);
@@ -69,11 +51,6 @@ async ([parent_bid, bid_attr_name]) => {
             );
         }
         i++;
-        // we will mark only standard HTML tags
-        if (!elem.tagName || !html_tags.has(elem.tagName.toLowerCase())) {
-            // Skipping element
-            continue;  // stop and move on to the next element
-        }
         // Processing element
         // register intersection callback on element, and keep track of element for waiting later
         elem.setAttribute('browsergym_visibility_ratio', 0);

--- a/browsergym/core/src/browsergym/core/javascript/frame_unmark_elements.js
+++ b/browsergym/core/src/browsergym/core/javascript/frame_unmark_elements.js
@@ -1,6 +1,6 @@
 /**
  * Go through all DOM elements in the frame (including shadowDOMs),
- * and cleanup previously stored data in the aria-roledescription attribute.
+ * and cleanup previously stored data in ARIA attributes.
  */
 () => {
     // get all DOM elements in the current frame (does not include elements in shadowDOMs)
@@ -18,23 +18,23 @@
             );
         }
         i++;
-        // Hack: remove custom data stored inside the aria-roledescription tag
+        // Hack: remove custom data stored in ARIA attributes
         //  - elem_global_id: global browsergym identifier
-        if (elem.hasAttribute("aria-roledescription")) {
-            let content = elem.getAttribute("aria-roledescription");
-            // TODO: handle more data if needed
-            let n_data_items = 1;  // bid
-            let post_data_index = 0;
-            for (let j = 0 ; j < n_data_items ; j++) {
-                post_data_index = content.indexOf("_", post_data_index) + 1;
-            }
-            original_content = content.substring(post_data_index);
-            if (original_content) {
-                elem.setAttribute("aria-roledescription", original_content);
-            }
-            else {
-                elem.removeAttribute("aria-roledescription");
-            }
+        pop_bid_from_attribute(elem, "aria-description");
+        pop_bid_from_attribute(elem, "aria-roledescription");  // fallback for generic nodes
+    }
+}
+
+function pop_bid_from_attribute(elem, attr) {
+    let bid_regex = /^browsergym_id[^\s]*\s/;
+    if (elem.hasAttribute(attr)) {
+        let content = elem.getAttribute(attr);
+        let original_content = content.replace(bid_regex, '');
+        if (original_content) {
+            elem.setAttribute(attr, original_content);
+        }
+        else {
+            elem.removeAttribute(attr);
         }
     }
 }

--- a/browsergym/core/src/browsergym/utils/obs.py
+++ b/browsergym/core/src/browsergym/utils/obs.py
@@ -239,7 +239,7 @@ def _process_bid(
             skip_element = True
         if filter_visible_only:
             # element without bid have no visibility mark, they could be visible or non-visible
-            # TODO: we consider them as visible. Is this what we want? Now that duplicate bids are handles, should we mark all non-html elements?
+            # TODO we consider them as visible. Is this what we want? Now that duplicate bids are handled, should we mark all non-html elements?
             pass  # keep elements without visible property
             # skip_element = True  # filter elements without visible property
 
@@ -283,6 +283,7 @@ def flatten_axtree_to_str(
     with_center_coords: bool = False,
     with_bounding_box_coords: bool = False,
     with_som: bool = False,
+    skip_generic: bool = True,
     filter_visible_only: bool = False,
     filter_with_bid_only: bool = False,
     filter_som_only: bool = False,
@@ -302,8 +303,8 @@ def flatten_axtree_to_str(
         tree_str = ""
         node = AX_tree["nodes"][node_idx]
         indent = "\t" * depth
-        skip_node = False
-        filter_node = False
+        skip_node = False  # node will not be printed, with no effect on children nodes
+        filter_node = False  # node will not be printed, possibly along with its children nodes
         node_role = node["role"]["value"]
         node_name = ""
 
@@ -320,8 +321,11 @@ def flatten_axtree_to_str(
             else:
                 node_value = None
 
+            # extract bid
+            bid = node.get("browsergym_id", None)
+
+            # extract node attributes
             attributes = []
-            bid = None
             for property in node.get("properties", []):
                 if not "value" in property:
                     continue
@@ -331,9 +335,7 @@ def flatten_axtree_to_str(
                 prop_name = property["name"]
                 prop_value = property["value"]["value"]
 
-                if prop_name == "browsergym_id":
-                    bid = prop_value
-                elif prop_name in ignored_properties:
+                if prop_name in ignored_properties:
                     continue
                 elif prop_name in ("required", "focused", "atomic"):
                     if prop_value:
@@ -341,7 +343,10 @@ def flatten_axtree_to_str(
                 else:
                     attributes.append(f"{prop_name}={repr(prop_value)}")
 
-            if node_role == "generic" and not attributes:
+            if skip_generic and node_role == "generic" and not attributes:
+                skip_node = True
+
+            if hide_all_children and parent_node_filtered:
                 skip_node = True
 
             if node_role == "StaticText":
@@ -365,14 +370,17 @@ def flatten_axtree_to_str(
                 )
 
                 # if either is True, skip the node
-                skip_node = skip_node or filter_node or (hide_all_children and parent_node_filtered)
+                skip_node = skip_node or filter_node
 
                 # insert extra attributes before regular attributes
                 attributes = extra_attributes_to_print + attributes
 
             # actually print the node string
             if not skip_node:
-                node_str = f"{node_role} {repr(node_name.strip())}"
+                if node_role == "generic" and not node_name:
+                    node_str = f"{node_role}"
+                else:
+                    node_str = f"{node_role} {repr(node_name.strip())}"
 
                 if not (
                     bid is None

--- a/tests/core/data/test_page_2.html
+++ b/tests/core/data/test_page_2.html
@@ -29,7 +29,7 @@
     </form>
 
     <nonhtmltag>
-        Text within in non-html tag
+        Text within a non-html tag
     </nonhtmltag>
     <br />
     <br />

--- a/tests/core/test_observation.py
+++ b/tests/core/test_observation.py
@@ -11,7 +11,6 @@ import regex as re
 import browsergym.core
 
 from browsergym.utils.obs import (
-    _remove_redundant_static_text,
     flatten_axtree_to_str,
     flatten_dom_to_str,
 )


### PR DESCRIPTION
 - [x] more robust remove_redundant_static_text in `flatten_axtree_to_str()`
 - [x] give bids to AXTree nodes with `role="generic"` (html divs and spans), by using the `aria-description` attribute as a fallback for bid injection (using `aria-roledescription` does not work for AXTree nodes with `role="generic"`)
 - [x] inject bids to all HTML elements, even non-standard ones