### PR TITLE
More robust frame marking

### DIFF
--- a/browsergym/core/src/browsergym/core/action/utils.py
+++ b/browsergym/core/src/browsergym/core/action/utils.py
@@ -8,7 +8,7 @@ def get_elem_by_bid(
     """
     Parse the given bid to sequentially locate every nested frame leading to the bid, then
     locate the bid element. Bids are expected to take the form "abDb123", which means
-    the element abDb123 is located inside frame abDAb, which is located inside frame abD,
+    the element abDb123 is located inside frame abDAb, which is located inside frame abDA,
     which is located inside frame a, which is located inside the page's main frame.
 
     Args:

--- a/browsergym/core/src/browsergym/core/action/utils.py
+++ b/browsergym/core/src/browsergym/core/action/utils.py
@@ -7,9 +7,9 @@ def get_elem_by_bid(
 ) -> playwright.sync_api.Locator:
     """
     Parse the given bid to sequentially locate every nested frame leading to the bid, then
-    locate the bid element. Bids are expected to take the form "abb123", which means
-    the element abb123 is located inside frame abb, which is located inside frame ab, which is
-    located inside frame a, which is located inside the page's main frame.
+    locate the bid element. Bids are expected to take the form "abDb123", which means
+    the element abDb123 is located inside frame abDAb, which is located inside frame abD,
+    which is located inside frame a, which is located inside the page's main frame.
 
     Args:
         bid: the browsergym id (playwright testid) of the page element.
@@ -28,6 +28,9 @@ def get_elem_by_bid(
     i = 0
     while bid[i:] and not bid[i:].isnumeric():
         i += 1
+        # allow multi-character frame ids such as aA, bCD etc.
+        while bid[i:] and bid[i].isalpha() and bid[i].isupper():
+            i += 1
         frame_bid = bid[:i]  # bid of the next frame to select
         frame_elem = current_frame.get_by_test_id(frame_bid)
         if not frame_elem.count():

--- a/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
+++ b/browsergym/core/src/browsergym/core/javascript/frame_mark_elements.js
@@ -121,13 +121,9 @@ async ([parent_bid, bid_attr_name, tags_to_mark]) => {
         }
         if (elem_global_bid === null) {
             let elem_local_id = null;
-            // iFrames get alphabetical ids: 'a', 'b', ..., 'z'.
-            // if more than 26 iFrames are present, raise an Error
+            // iFrames get alphabetical ids: 'a', 'b', ..., 'z', 'aA', 'aB' etc.
             if (['iframe', 'frame'].includes(elem.tagName.toLowerCase())) {
                 elem_local_id = `${window.browsergym_frame_id_generator.next()}`;
-                if (elem_local_id.length > 1) {
-                    throw new Error(`More than 26? Such iFrames. BrowserGym not like.`);
-                }
             }
             // other elements get numerical ids: '0', '1', '2', ...
             else {
@@ -268,8 +264,13 @@ class IFrameIdGenerator {
 
     next() {
       const r = [];
-      for (const char of this._nextId) {
-        r.unshift(this._chars[char]);
+      for (let i = 0; i < this._nextId.length; i++) {
+        let char = this._chars[this._nextId[i]];
+        // all but first character must be upper-cased (a, aA, bCD)
+        if (i < this._nextId.length - 1) {
+            char = char.toUpperCase();
+        }
+        r.unshift(char);
       }
       this._increment();
       return r.join('');

--- a/browsergym/core/src/browsergym/core/observation.py
+++ b/browsergym/core/src/browsergym/core/observation.py
@@ -36,7 +36,7 @@ def _pre_extract(
     # we can't run this loop in JS due to Same-Origin Policy
     # (can't access the content of an iframe from a another one)
     def mark_frames_recursive(frame, frame_bid: str):
-        assert frame_bid == "" or re.match(r"^[a-z][A-Z]*$", frame_bid)
+        assert frame_bid == "" or re.match(r"^[a-z][a-zA-Z]*$", frame_bid)
         logger.debug(f"Marking frame {repr(frame_bid)}")
 
         # mark all DOM elements in the frame (it will use the parent frame element's bid as a prefix)

--- a/browsergym/core/src/browsergym/core/observation.py
+++ b/browsergym/core/src/browsergym/core/observation.py
@@ -36,7 +36,8 @@ def _pre_extract(
     # we can't run this loop in JS due to Same-Origin Policy
     # (can't access the content of an iframe from a another one)
     def mark_frames_recursive(frame, frame_bid: str):
-        assert frame_bid == "" or (frame_bid.islower() and frame_bid.isalpha())
+        assert frame_bid == "" or re.match(r"^[a-z][A-Z]*$", frame_bid)
+        logger.debug(f"Marking frame {repr(frame_bid)}")
 
         # mark all DOM elements in the frame (it will use the parent frame element's bid as a prefix)
         warning_msgs = frame.evaluate(
@@ -137,7 +138,7 @@ def extract_screenshot(page: playwright.sync_api.Page):
 
 
 # we could handle more data items here if needed
-__BID_EXPR = r"([a-z0-9]+)"
+__BID_EXPR = r"([a-zA-Z0-9]+)"
 __DATA_REGEXP = re.compile(r"^browsergym_id_" + __BID_EXPR + r"\s?" + r"(.*)")
 
 

--- a/browsergym/core/src/browsergym/core/observation.py
+++ b/browsergym/core/src/browsergym/core/observation.py
@@ -80,17 +80,19 @@ def _post_extract(page: playwright.sync_api.Page):
     # we can't run this loop in JS due to Same-Origin Policy
     # (can't access the content of an iframe from a another one)
     for frame in page.frames:
-        if not frame == page.main_frame:
-            # deal with weird frames (pdf viewer in <embed>)
-            if not frame.frame_element().content_frame() == frame:
-                logger.warning(f"Skipping frame '{frame.name}' for unmarking, seems problematic.")
-                continue
-            # deal with sandboxed frames with blocked script execution
-            sandbox_attr = frame.frame_element().get_attribute("sandbox")
-            if sandbox_attr is not None and "allow-scripts" not in sandbox_attr.split():
-                continue
-
         try:
+            if not frame == page.main_frame:
+                # deal with weird frames (pdf viewer in <embed>)
+                if not frame.frame_element().content_frame() == frame:
+                    logger.warning(
+                        f"Skipping frame '{frame.name}' for unmarking, seems problematic."
+                    )
+                    continue
+                # deal with sandboxed frames with blocked script execution
+                sandbox_attr = frame.frame_element().get_attribute("sandbox")
+                if sandbox_attr is not None and "allow-scripts" not in sandbox_attr.split():
+                    continue
+
             frame.evaluate(js_frame_unmark_elements)
         except playwright.sync_api.Error as e:
             if "Frame was detached" in str(e):

--- a/tests/core/data/lots_of_iframes.html
+++ b/tests/core/data/lots_of_iframes.html
@@ -7,24 +7,12 @@
 
 <body>
     <script>
-
-        function escapeHtml(unsafe) {
-            return unsafe;
-            //.replace(/&/g, "&amp;amp;")
-            // .replace(/</g, "&lt;")
-            // .replace(/>/g, "&gt;")
-            // .replace(/'/g, "&#039;"
-            //.replace(/"/g, "&quot;");
-        }
-
         for (let i = 0; i < 30; i++) {
             const iframe = document.createElement('iframe');
-            html = `
+            iframe.srcdoc = `
 This is IFrame ${i}.
 <input type='checkbox' id='checkbox${i}'>
 `
-            // Escape characters
-            iframe.srcdoc = escapeHtml(html);
             document.body.appendChild(iframe);
         }
     </script>

--- a/tests/core/data/lots_of_iframes.html
+++ b/tests/core/data/lots_of_iframes.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Lots of Iframes</title>
+</head>
+
+<body>
+    <script>
+
+        function escapeHtml(unsafe) {
+            return unsafe;
+            //.replace(/&/g, "&amp;amp;")
+            // .replace(/</g, "&lt;")
+            // .replace(/>/g, "&gt;")
+            // .replace(/'/g, "&#039;"
+            //.replace(/"/g, "&quot;");
+        }
+
+        for (let i = 0; i < 30; i++) {
+            const iframe = document.createElement('iframe');
+            html = `
+This is IFrame ${i}.
+<input type='checkbox' id='checkbox${i}'>
+`
+            // Escape characters
+            iframe.srcdoc = escapeHtml(html);
+            document.body.appendChild(iframe);
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
 - [x] Handle `Frame was detached` errors while unmarking
 - [x] remove limit on maximum number of iFrames (26)

iframe IDs can now go above single-digit.
First digit is lowercase, then uppercase: a-z, then aA-aZ, then bA-bZ etc.
Example bid of an element within 4 iFrames: `abaGbHG43` (`a`-`b`-`aG`-`bHG` - `43`)