### PR TITLE
Pyparser minor fix

### DIFF
--- a/browsergym/core/src/browsergym/core/action/highlevel.py
+++ b/browsergym/core/src/browsergym/core/action/highlevel.py
@@ -316,11 +316,12 @@ Only a single action can be provided at once."""
         # the corresponding python function call
         if self.strict:
             function_calls = highlevel_action_parser.parse_string(highlevel_code, parse_all=True)
+            function_calls = function_calls.as_list()
         else:
             function_calls = highlevel_action_parser.search_string(
                 highlevel_code
             )  # allow for multiple matches, skip anything in-between
-            function_calls = sum(function_calls, [])  # unpack multiple matches
+            function_calls = sum(function_calls.as_list(), [])  # unpack multiple matches
 
         if not function_calls:
             raise ValueError("Received an empty action.")

--- a/browsergym/core/src/browsergym/core/action/highlevel.py
+++ b/browsergym/core/src/browsergym/core/action/highlevel.py
@@ -320,7 +320,7 @@ Only a single action can be provided at once."""
             function_calls = highlevel_action_parser.search_string(
                 highlevel_code
             )  # allow for multiple matches, skip anything in-between
-            function_calls = sum(function_calls)  # unpack multiple matches
+            function_calls = sum(function_calls, [])  # unpack multiple matches
 
         if not function_calls:
             raise ValueError("Received an empty action.")

--- a/tests/core/test_actions_highlevel.py
+++ b/tests/core/test_actions_highlevel.py
@@ -135,6 +135,20 @@ def test_valid_action():
     assert not obs["last_action_error"]
     assert not checkbox.has_attr("checked")
 
+    # typo in action (unescaped double quotes)
+    action = f"""\
+click({repr(checkbox.get(BID_ATTR))}, "17" screen")  # typo here
+"""
+    with pytest.raises(ValueError):
+        python_action = action_set.to_python_code(action)
+
+    obs, reward, term, trunc, info = env.step(action)
+    checkbox = get_checkbox_elem(obs)
+
+    # error and box not checked
+    assert "Received an empty action." in obs["last_action_error"]
+    assert not checkbox.has_attr("checked")
+
     # click box 1 time
     action = f"""\
 click({repr(checkbox.get(BID_ATTR))})


### PR DESCRIPTION
Before: `sum(function_calls)` would return `0` when no function call was recognized.
After: `sum(function_calls.to_list(), [])` returns an empty list `[]` as expected.

Note: because we were doing `if not function_calls:` afterwards, this does not affect the behaviour of the action space.