### PR TITLE
Lenient frame marking in last retry

### DIFF
--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -520,7 +520,7 @@ document.addEventListener("visibilitychange", () => {
         for retries_left in reversed(range(EXTRACT_OBS_MAX_TRIES)):
             try:
                 # pre-extraction, mark dom elements (set bid, set dynamic attributes like value and checked)
-                _pre_extract(self.page, self.tags_to_mark)
+                _pre_extract(self.page, tags_to_mark=self.tags_to_mark, lenient=(retries_left == 0))
 
                 dom = extract_dom_snapshot(self.page)
                 axtree = extract_merged_axtree(self.page)

--- a/browsergym/core/src/browsergym/core/observation.py
+++ b/browsergym/core/src/browsergym/core/observation.py
@@ -24,7 +24,9 @@ class MarkingError(Exception):
 
 
 def _pre_extract(
-    page: playwright.sync_api.Page, tags_to_mark: Literal["all", "standard_html"] = "standard_html"
+    page: playwright.sync_api.Page,
+    tags_to_mark: Literal["all", "standard_html"] = "standard_html",
+    lenient: bool = False,
 ):
     """
     pre-extraction routine, marks dom elements (set bid and dynamic attributes like value and checked)
@@ -66,7 +68,11 @@ def _pre_extract(
                 continue
             child_frame_bid = child_frame_elem.get_attribute(BID_ATTR)
             if child_frame_bid is None:
-                raise MarkingError("Cannot mark a child frame without a bid.")
+                if lenient:
+                    logger.warning("Cannot mark a child frame without a bid. Skipping frame.")
+                    continue
+                else:
+                    raise MarkingError("Cannot mark a child frame without a bid.")
             mark_frames_recursive(child_frame, frame_bid=child_frame_bid)
 
     # mark all frames recursively


### PR DESCRIPTION
Should address a few problematic "Cannot mark a child frame without a bid." cases.