### PR TITLE
limiting python version for agentlab tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '>=3.10'
+          python-version: '>=3.10,<3.13'
           cache: 'pip' # caching pip dependencies
 
       - name: Install AgentLab

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '>=3.10,<3.13'
+          python-version: '<3.13'
           cache: 'pip' # caching pip dependencies
 
       - name: Install AgentLab


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Limit the Python version for AgentLab tests to be greater than or equal to 3.10 and less than 3.13 in the GitHub Actions workflow.

### Why are these changes being made?

This change ensures compatibility with the latest stable Python releases, while excluding any future releases beyond 3.12 that may introduce breaking changes or undetected issues within AgentLab tests. By narrowly defining the range, we prevent potential compatibility problems that could arise with newer Python features not yet supported by AgentLab.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->