### PR TITLE
Make run_massage picklable

### DIFF
--- a/browsergym/experiments/src/browsergym/experiments/benchmark/utils.py
+++ b/browsergym/experiments/src/browsergym/experiments/benchmark/utils.py
@@ -225,6 +225,30 @@ def massage_tasks(task_ids: list[str], max_retries: int = 1, timeout: int = 60):
                 )
 
 
+def run_massage(outcome_queue: mp.Queue, task_id: str):
+    import gymnasium as gym
+
+    gym_id = f"browsergym/{task_id}"
+    env = gym.make(gym_id)
+    no_action = "noop()"
+    # check if action space exists and is compatible with "noop()"
+    try:
+        env.unwrapped.action_mapping(no_action)
+    except:
+        no_action = ""  # fallback plan
+    # run massage
+    try:
+        env.reset()  # task setup
+        env.step(no_action)  # task validation
+        env.step(no_action)  # task validation again
+        outcome = "success", None
+    except Exception as e:
+        outcome = "exception", traceback.format_exception(e)
+    finally:
+        env.close()
+        outcome_queue.put(outcome)
+
+
 def massage_task_within_subprocess(
     task_id: str, timeout: int, kill_timeout: int = 10
 ) -> typing.Tuple[str, str]:
@@ -236,31 +260,8 @@ def massage_task_within_subprocess(
       - err_msg: error message if any, or None.
     """
 
-    def run_massage(outcome_queue: mp.Queue):
-        import gymnasium as gym
-
-        gym_id = f"browsergym/{task_id}"
-        env = gym.make(gym_id)
-        no_action = "noop()"
-        # check if action space exists and is compatible with "noop()"
-        try:
-            env.unwrapped.action_mapping(no_action)
-        except:
-            no_action = ""  # fallback plan
-        # run massage
-        try:
-            env.reset()  # task setup
-            env.step(no_action)  # task validation
-            env.step(no_action)  # task validation again
-            outcome = "success", None
-        except Exception as e:
-            outcome = "exception", traceback.format_exception(e)
-        finally:
-            env.close()
-            outcome_queue.put(outcome)
-
     queue = mp.Queue()
-    process = mp.Process(target=run_massage, args=(queue,))
+    process = mp.Process(target=run_massage, args=(queue, task_id))
     process.start()
     process.join(timeout=timeout)
 


### PR DESCRIPTION
I was having issue #327 because `run_massage` was defined inside a function.
I moved it outside and this fixes it

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `run_massage` function to be picklable by moving it outside of `massage_task_within_subprocess` and modifying its parameters to include `task_id`.

### Why are these changes being made?
This change addresses a limitation with the multiprocessing library that requires target callable functions to be picklable, which wasn't possible with the inner function structure. By moving `run_massage` outside, we ensure compatibility with process-based parallel execution, a necessary step for improving code modularity and functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->