### PR TITLE
added a n_repeat functionality to make_env_args_list_from_fixed_seeds()

### DIFF
--- a/browsergym/experiments/src/browsergym/experiments/benchmark/utils.py
+++ b/browsergym/experiments/src/browsergym/experiments/benchmark/utils.py
@@ -73,7 +73,7 @@ def make_env_args_list_from_repeat_tasks(
 
 
 def make_env_args_list_from_fixed_seeds(
-    task_list: list[str], max_steps: int, fixed_seeds: list[int]
+    task_list: list[str], max_steps: int, fixed_seeds: list[int], n_repeats: int = 1
 ):
     """
     Generates a list of `len(task_list)` time `n_repeats` environments arguments, using randomly generated seeds.
@@ -81,20 +81,21 @@ def make_env_args_list_from_fixed_seeds(
     env_args_list = []
     for task in task_list:
         for seed in fixed_seeds:
-            env_args_list.append(
-                EnvArgs(
-                    task_name=task,
-                    task_seed=int(seed),
-                    max_steps=max_steps,
-                    headless=True,
-                    record_video=False,
-                    wait_for_user_message=False,
-                    viewport=None,
-                    slow_mo=None,
-                    storage_state=None,
-                    task_kwargs=None,
+            for _ in range(n_repeats):
+                env_args_list.append(
+                    EnvArgs(
+                        task_name=task,
+                        task_seed=int(seed),
+                        max_steps=max_steps,
+                        headless=True,
+                        record_video=False,
+                        wait_for_user_message=False,
+                        viewport=None,
+                        slow_mo=None,
+                        storage_state=None,
+                        task_kwargs=None,
+                    )
                 )
-            )
 
     return env_args_list
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an `n_repeats` functionality to the `make_env_args_list_from_fixed_seeds()` function to allow generating repeated environment arguments for the given seeds and tasks.

### Why are these changes being made?

This change allows for greater flexibility and testing of robustness by enabling multiple repetitions of environments for each task and seed combination, which was previously limited to only one set of environment arguments per seed. The inclusion of `n_repeats` parameter allows the function to efficiently handle cases where repeated trials are necessary to gather more comprehensive insights during experimentation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->