### PR TITLE
Bump weblinx version in pyproject.toml

### DIFF
--- a/browsergym/pyproject.toml
+++ b/browsergym/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "browsergym-assistantbench==0.13.3",
     "browsergym-experiments==0.13.3",
     "browsergym-workarena>=0.4.1",
-    "weblinx-browsergym>=0.0.1dev14",
+    "weblinx-browsergym>=0.0.2",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
the new version 0.0.2 changes the use of snapshot_download to hf_hub_download to avoid issues downloading metadat.json

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `weblinx-browsergym` version in `pyproject.toml` from `>=0.0.1dev14` to `>=0.0.2`.

### Why are these changes being made?

This change upgrades the dependency to a more stable release, which addresses minor fixes and potential improvements not available in the previous development version. This ensures better compatibility and reliability for the project using this package.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->