### PR TITLE
Make miniwob installation automatic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,7 @@ tests/assistantbench/assistantbench-predictions-test.jsonl
 # weblinx
 bg_wl_data/
 
+# miniwob setup
+miniwob-plusplus/
+
 uv.lock

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,39 @@ demo:
 	@echo "--- 🚀 Running demo agent ---"
 	(set -x && cd demo_agent && python run_demo.py)
 
+setup-miniwob:
+	@echo "--- 🤖 Setting up MiniWoB++ ---"
+	@if [ ! -d "miniwob-plusplus" ]; then \
+		echo "Cloning MiniWoB++ repository..."; \
+		git clone https://github.com/Farama-Foundation/miniwob-plusplus.git; \
+	else \
+		echo "MiniWoB++ repository already exists, skipping clone..."; \
+	fi
+	@echo "Resetting to specific commit for reproducibility..."
+	git -C "./miniwob-plusplus" reset --hard 7fd85d71a4b60325c6585396ec4f48377d049838
+	@echo "Adding MINIWOB_URL to .env file..."
+	@echo "MINIWOB_URL=\"file://$(shell pwd)/miniwob-plusplus/miniwob/html/miniwob/\"" >> .env
+	@echo "✅ MiniWoB++ setup complete!"
+	@echo "💡 To use MiniWoB++, load the environment variables:"
+	@echo "   source .env"
+
 test-core:
 	@echo "--- 🧪 Running tests ---"
 	pytest -n auto ./tests/core
+
+clean-miniwob:
+	@echo "--- 🧹 Cleaning MiniWoB++ installation ---"
+	rm -rf miniwob-plusplus
+	@echo "✅ MiniWoB++ installation cleaned!"
+
+help:
+	@echo "Available targets:"
+	@echo "  install          - Install project dependencies"
+	@echo "  setup-miniwob    - Setup MiniWoB++ dependencies"
+	@echo "  install-demo     - Install demo dependencies"
+	@echo "  demo             - Run demo agent"
+	@echo "  test-core        - Run core tests"
+	@echo "  clean-miniwob    - Remove MiniWoB++ directory"
+	@echo "  help             - Show this help message"
+
+.PHONY: install setup-miniwob install-demo demo test-core clean-miniwob help

--- a/browsergym/miniwob/README.md
+++ b/browsergym/miniwob/README.md
@@ -4,18 +4,43 @@ This package provides `browsergym.miniwob`, which is an unofficial port of the [
 
 ## Setup
 
+### Option 1: Automated setup (Recommended)
+
+If you're working from the BrowserGym root directory, you can use the Makefile for automated setup:
+
+```sh
+make setup-miniwob
+```
+
+This will:
+
+- Clone the MiniWoB++ repository
+- Reset to the specific commit for reproducibility  
+- Add the `MINIWOB_URL` to your `.env` file
+
+Then load the environment variables:
+
+```sh
+source .env
+```
+
+### Option 2: Manual setup
+
 1. Install the package
+
 ```sh
 pip install browsergym-miniwob
 ```
 
-2. Clone miniwob (use a specific frozen commit for reproducibility)
+1. Clone miniwob (use a specific frozen commit for reproducibility)
+
 ```sh
 git clone git@github.com:Farama-Foundation/miniwob-plusplus.git
 git -C "./miniwob-plusplus" reset --hard 7fd85d71a4b60325c6585396ec4f48377d049838
 ```
 
-3. Setup Miniwob URL (change `PATH_TO_MINIWOB_CLONED_REPO` here to the absolute path to your `miniwob-plusplus` folder)
+1. Setup Miniwob URL (change `PATH_TO_MINIWOB_CLONED_REPO` here to the absolute path to your `miniwob-plusplus` folder)
+
 ```sh
 export MINIWOB_URL="file://<PATH_TO_MINIWOB_CLONED_REPO>/miniwob/html/miniwob/"
 ```


### PR DESCRIPTION
This pull request introduces a new setup process for the MiniWoB++ environment, adds related utility commands to the `Makefile`, and updates the documentation to reflect these changes. These updates aim to streamline the setup process and improve clarity for users.

### Enhancements to MiniWoB++ setup:

* **Automated MiniWoB++ setup in `Makefile`:** Added a `setup-miniwob` target to automate the cloning of the MiniWoB++ repository, resetting it to a specific commit for reproducibility, and appending the `MINIWOB_URL` to the `.env` file. Also included a `clean-miniwob` target to remove the MiniWoB++ directory.

* **Help command in `Makefile`:** Introduced a `help` target to list all available Makefile commands, including the new MiniWoB++ setup and clean commands.

### Documentation updates:

* **Automated setup instructions in `README.md`:** Added a new "Option 1: Automated setup" section to guide users in setting up MiniWoB++ using the `setup-miniwob` Makefile command. Updated the manual setup instructions to reflect the same reproducibility practices.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Automate the MiniWoB++ installation process with a new `setup-miniwob` target in the Makefile, update the README with instructions for automated and manual setup, and add the MiniWoB++ directory to `.gitignore`.

### Why are these changes being made?

These changes simplify the setup of MiniWoB++ by providing an automated option, reducing manual steps and potential errors. This approach ensures reproducibility by resetting to a specific commit and makes the setup process more user-friendly while maintaining a manual option for those who prefer it. Adding the directory to `.gitignore` prevents unwanted files from being tracked in git.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->