### PR TITLE
update webarenalite requirement and toml

### DIFF
--- a/browsergym/pyproject.toml
+++ b/browsergym/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "browsergym-experiments==0.14.2",
     "browsergym-workarena>=0.4.1",
     "weblinx-browsergym>=0.0.2",
+    "browsergym-webarenalite==0.14.2"
 ]
 
 [tool.setuptools]

--- a/browsergym/webarenalite/requirements.txt
+++ b/browsergym/webarenalite/requirements.txt
@@ -1,2 +1,3 @@
 browsergym-core==0.14.2
+browsergym-webarena==0.14.2
 libwebarena==0.0.4


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

- Add browsergym-webarenalite==0.14.2 to browsergym/pyproject.toml dependencies.
- Add browsergym-webarena==0.14.2 to browsergym/webarenalite/requirements.txt to pin the corresponding runtime dependency.

### Why are these changes being made?

Ensure the webarenalite integration is explicitly pinned to compatible versions and resolves correctly. This aligns the top-level and subproject dependencies for a stable build.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->