### PR TITLE
Strip trailing slash from WebArena URLs (#366)

### DIFF
--- a/browsergym/visualwebarena/src/browsergym/visualwebarena/instance.py
+++ b/browsergym/visualwebarena/src/browsergym/visualwebarena/instance.py
@@ -4,7 +4,7 @@ import os
 import playwright.sync_api
 
 # we inherit some code base from webarena to avoid too much duplication
-from browsergym.webarena.instance import WebArenaInstance
+from browsergym.webarena.instance import WebArenaInstance, _strip_trailing_slashes
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +46,15 @@ class VisualWebArenaInstance(WebArenaInstance):
             WIKIPEDIA,
         )
 
-        self.urls = {
-            "reddit": REDDIT,
-            "shopping": SHOPPING,
-            "wikipedia": WIKIPEDIA,
-            "classifieds": CLASSIFIEDS,
-        }
-        self.home_url = HOMEPAGE
+        self.urls = _strip_trailing_slashes(
+            {
+                "reddit": REDDIT,
+                "shopping": SHOPPING,
+                "wikipedia": WIKIPEDIA,
+                "classifieds": CLASSIFIEDS,
+            }
+        )
+        self.home_url = HOMEPAGE.rstrip("/")
         self.classifieds_reset_token = CLASSIFIEDS_RESET_TOKEN
 
         self.credentials = ACCOUNTS

--- a/browsergym/webarena/README.md
+++ b/browsergym/webarena/README.md
@@ -29,7 +29,7 @@ python -c "import nltk; nltk.download('punkt_tab')"
 BASE_URL=<YOUR_SERVER_URL_HERE>  # example: "http://myazuremachine.eastus.cloudapp.azure.com"
 
 # webarena environment variables (change ports as needed)
-export WA_SHOPPING="$BASE_URL:8082/"
+export WA_SHOPPING="$BASE_URL:8082"
 export WA_SHOPPING_ADMIN="$BASE_URL:8083/admin"
 export WA_REDDIT="$BASE_URL:8080"
 export WA_GITLAB="$BASE_URL:9001"

--- a/browsergym/webarena/src/browsergym/webarena/instance.py
+++ b/browsergym/webarena/src/browsergym/webarena/instance.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 ENV_VARS = ("SHOPPING", "SHOPPING_ADMIN", "REDDIT", "GITLAB", "WIKIPEDIA", "MAP", "HOMEPAGE")
 
 
+def _strip_trailing_slashes(urls: dict) -> dict:
+    return {site: url.rstrip("/") for site, url in urls.items()}
+
+
 class WebArenaInstance:
     """
     Utility class to access a WebArena instance.
@@ -44,15 +48,17 @@ class WebArenaInstance:
             WIKIPEDIA,
         )
 
-        self.urls = {
-            "reddit": REDDIT,
-            "gitlab": GITLAB,
-            "shopping": SHOPPING,
-            "shopping_admin": SHOPPING_ADMIN,
-            "wikipedia": WIKIPEDIA,
-            "map": MAP,
-        }
-        self.home_url = HOMEPAGE
+        self.urls = _strip_trailing_slashes(
+            {
+                "reddit": REDDIT,
+                "gitlab": GITLAB,
+                "shopping": SHOPPING,
+                "shopping_admin": SHOPPING_ADMIN,
+                "wikipedia": WIKIPEDIA,
+                "map": MAP,
+            }
+        )
+        self.home_url = HOMEPAGE.rstrip("/")
 
         self.credentials = ACCOUNTS
 

--- a/browsergym/webarena/src/browsergym/webarena/task.py
+++ b/browsergym/webarena/src/browsergym/webarena/task.py
@@ -17,6 +17,22 @@ from .instance import WebArenaInstance
 logger = logging.getLogger(__name__)
 
 
+URL_PATTERNS = {
+    "__GITLAB__": "gitlab",
+    "__REDDIT__": "reddit",
+    "__SHOPPING__": "shopping",
+    "__SHOPPING_ADMIN__": "shopping_admin",
+    "__WIKIPEDIA__": "wikipedia",
+    "__MAP__": "map",
+}
+
+
+def substitute_urls(configs_str: str, urls: dict) -> str:
+    for pattern, url_key in URL_PATTERNS.items():
+        configs_str = configs_str.replace(pattern, urls[url_key])
+    return configs_str
+
+
 class GenericWebArenaTask(AbstractBrowserTask):
     """
     Base class for all WebArena tasks.
@@ -54,16 +70,7 @@ class GenericWebArenaTask(AbstractBrowserTask):
 
         all_configs_str = importlib.resources.files(webarena).joinpath("test.raw.json").read_text()
 
-        # substitute URLs
-        for pattern, url_key in {
-            "__GITLAB__": "gitlab",
-            "__REDDIT__": "reddit",
-            "__SHOPPING__": "shopping",
-            "__SHOPPING_ADMIN__": "shopping_admin",
-            "__WIKIPEDIA__": "wikipedia",
-            "__MAP__": "map",
-        }.items():
-            all_configs_str = all_configs_str.replace(pattern, self.webarena_instance.urls[url_key])
+        all_configs_str = substitute_urls(all_configs_str, self.webarena_instance.urls)
 
         # load all task configs to JSON
         all_configs = json.loads(all_configs_str)

--- a/browsergym/webarena_verified/src/browsergym/webarena_verified/task.py
+++ b/browsergym/webarena_verified/src/browsergym/webarena_verified/task.py
@@ -10,7 +10,7 @@ from typing import Optional
 import playwright._impl._errors as playwright_errors
 import playwright.sync_api
 
-from browsergym.webarena.task import GenericWebArenaTask
+from browsergym.webarena.task import GenericWebArenaTask, substitute_urls
 from browsergym.webarena_verified.evaluators import WebArenaVerifiedEvaluator
 from webarena_verified.types import FinalAgentResponse
 
@@ -51,16 +51,7 @@ class WebArenaVerifiedTask(GenericWebArenaTask):
             .read_text()
         )
 
-        # substitute URLs
-        for pattern, url_key in {
-            "__GITLAB__": "gitlab",
-            "__REDDIT__": "reddit",
-            "__SHOPPING__": "shopping",
-            "__SHOPPING_ADMIN__": "shopping_admin",
-            "__WIKIPEDIA__": "wikipedia",
-            "__MAP__": "map",
-        }.items():
-            all_configs_str = all_configs_str.replace(pattern, self.webarena_instance.urls[url_key])
+        all_configs_str = substitute_urls(all_configs_str, self.webarena_instance.urls)
 
         # load all task configs to JSON
         all_configs = json.loads(all_configs_str)

--- a/browsergym/webarenalite/src/browsergym/webarenalite/helper_functions.py
+++ b/browsergym/webarenalite/src/browsergym/webarenalite/helper_functions.py
@@ -23,6 +23,13 @@ from webarena.llms.providers.openai_utils import (
     generate_from_openai_chat_completion,
 )
 
+GITLAB = GITLAB.rstrip("/")
+MAP = MAP.rstrip("/")
+REDDIT = REDDIT.rstrip("/")
+SHOPPING = SHOPPING.rstrip("/")
+SHOPPING_ADMIN = SHOPPING_ADMIN.rstrip("/")
+WIKIPEDIA = WIKIPEDIA.rstrip("/")
+
 
 def shopping_get_auth_token() -> str:
     response = requests.post(

--- a/browsergym/webarenalite/src/browsergym/webarenalite/task.py
+++ b/browsergym/webarenalite/src/browsergym/webarenalite/task.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import playwright.sync_api
 
-from browsergym.webarena.task import GenericWebArenaTask
+from browsergym.webarena.task import GenericWebArenaTask, substitute_urls
 
 logger = logging.getLogger(__name__)
 
@@ -40,16 +40,7 @@ class WebArenaLiteTask(GenericWebArenaTask):
             .joinpath("test_webarena_lite.raw.json")
             .read_text()
         )
-        # substitute URLs
-        for pattern, url_key in {
-            "__GITLAB__": "gitlab",
-            "__REDDIT__": "reddit",
-            "__SHOPPING__": "shopping",
-            "__SHOPPING_ADMIN__": "shopping_admin",
-            "__WIKIPEDIA__": "wikipedia",
-            "__MAP__": "map",
-        }.items():
-            all_configs_str = all_configs_str.replace(pattern, self.webarena_instance.urls[url_key])
+        all_configs_str = substitute_urls(all_configs_str, self.webarena_instance.urls)
 
         # load all task configs to JSON
         all_configs = json.loads(all_configs_str)

--- a/tests/webarena/test_url_substitution.py
+++ b/tests/webarena/test_url_substitution.py
@@ -1,0 +1,74 @@
+import json
+import os
+import sys
+import types
+
+import pytest
+
+
+ENV_URLS = {
+    "WA_SHOPPING": "http://host:8082/",
+    "WA_SHOPPING_ADMIN": "http://host:8083/admin/",
+    "WA_REDDIT": "http://host:8080/",
+    "WA_GITLAB": "http://host:9001/",
+    "WA_WIKIPEDIA": "http://host:8081/wikipedia/",
+    "WA_MAP": "http://host:443/",
+    "WA_HOMEPAGE": "http://host:80/",
+}
+
+
+@pytest.fixture
+def fake_webarena(monkeypatch):
+    for k, v in ENV_URLS.items():
+        monkeypatch.setenv(k, v)
+
+    pkg = types.ModuleType("webarena")
+    browser_env = types.ModuleType("webarena.browser_env")
+    env_config = types.ModuleType("webarena.browser_env.env_config")
+    for name in ("SHOPPING", "SHOPPING_ADMIN", "REDDIT", "GITLAB", "WIKIPEDIA", "MAP", "HOMEPAGE"):
+        setattr(env_config, name, os.environ[f"WA_{name}"])
+    env_config.ACCOUNTS = {}
+
+    monkeypatch.setitem(sys.modules, "webarena", pkg)
+    monkeypatch.setitem(sys.modules, "webarena.browser_env", browser_env)
+    monkeypatch.setitem(sys.modules, "webarena.browser_env.env_config", env_config)
+
+
+@pytest.mark.parametrize(
+    "site", ["reddit", "gitlab", "shopping", "shopping_admin", "wikipedia", "map"]
+)
+def test_urls_stripped(fake_webarena, site):
+    from browsergym.webarena.instance import WebArenaInstance
+
+    assert not WebArenaInstance().urls[site].endswith("/")
+
+
+def test_home_url_stripped(fake_webarena):
+    from browsergym.webarena.instance import WebArenaInstance
+
+    assert not WebArenaInstance().home_url.endswith("/")
+
+
+@pytest.mark.parametrize(
+    "placeholder,path",
+    [
+        ("__SHOPPING__", "/catalogsearch/result/?q=xbox"),
+        ("__SHOPPING_ADMIN__", "/sales/order/view/order_id/1/"),
+        ("__REDDIT__", "/f/AskReddit"),
+        ("__GITLAB__", "/root/some-project"),
+        ("__WIKIPEDIA__", "/wikipedia_en_all_maxi_2022-05/A/Alpha"),
+        ("__MAP__", "/?q=Pittsburgh"),
+    ],
+)
+def test_no_double_slash(fake_webarena, placeholder, path):
+    from browsergym.webarena.instance import WebArenaInstance
+    from browsergym.webarena.task import substitute_urls
+
+    raw = json.dumps({"eval": {"reference_url": f"{placeholder}{path}"}})
+    out = json.loads(substitute_urls(raw, WebArenaInstance().urls))
+    ref = out["eval"]["reference_url"]
+
+    first = path.lstrip("/").split("/")[0].split("?")[0]
+    if first:
+        assert f"//{first}" not in ref
+    assert ref.endswith(path)


### PR DESCRIPTION
Fixes #366.

If `WA_SHOPPING` (or any of the other site env vars) ends with `/`, the config-file URL substitution produces things like `http://host:8082//catalogsearch/result/?q=xbox`. The evaluator compares that string to `page.url`, which the browser normalizes to a single `/`, so shopping tasks like 274/275 score 0 even when the agent gets to the right page.

## Changes
- `WebArenaInstance` / `VisualWebArenaInstance`: strip trailing `/` from every URL (and `home_url`) via a small `_strip_trailing_slashes` helper.
- `webarenalite/helper_functions.py`: same fix for the `SHOPPING`/etc. constants it imports directly.
- Pulled the substitution dict + loop out of `webarena/task.py` into `URL_PATTERNS` + `substitute_urls()`, and reused it from `webarenalite/task.py` and `webarena_verified/task.py` instead of three copies.
- Fixed the README example (`WA_SHOPPING="$BASE_URL:8082/"` → `"$BASE_URL:8082"`).

## Note on compatibility
`instance.urls["shopping"]` etc. used to preserve whatever trailing slash the env var had; it no longer will. Downstream code that joined URLs without a leading `/` would break, but I didn't find any such usage in-repo.

## Tests
New `tests/webarena/test_url_substitution.py` stubs out `webarena.browser_env.env_config` so it runs without a live instance. 13 parametrized cases covering all six sites at both the URL-normalization and substitution-output level. Verified they fail on `main` and pass with this change.