### PR TITLE
Add OpenApps benchmark support in lazy import

### DIFF
--- a/browsergym/experiments/src/browsergym/experiments/loop.py
+++ b/browsergym/experiments/src/browsergym/experiments/loop.py
@@ -942,6 +942,8 @@ def _get_env_name(task_name: str):
         import browsergym.visualwebarena
     elif task_name.startswith("assistantbench"):
         import browsergym.assistantbench
+    elif task_name.startswith("openapps"):
+        import browsergym.openapps
     elif task_name.startswith("weblinx"):
         import weblinx_browsergym
     elif task_name.startswith("timewarp"):


### PR DESCRIPTION
## Summary
Adds OpenApps to the `_get_env_name` lazy import mechanism, so that 
OpenApps tasks are properly registered when running experiments via 
BrowserGym/AgentLab.

## Changes
- Added `elif task_name.startswith("openapps")` branch in `_get_env_name()` 
  that imports `browsergym.openapps` to trigger task registration.

## Related
- OpenApps benchmark: https://facebookresearch.github.io/OpenApps/
- This mirrors how other benchmarks (miniwob, workarena, etc.) are handled.