### PR TITLE
fix(core): parse strings with # and escaped quotes in highlevel_action_parser

### DIFF
--- a/browsergym/core/src/browsergym/core/action/parsers.py
+++ b/browsergym/core/src/browsergym/core/action/parsers.py
@@ -46,7 +46,19 @@ def _build_highlevel_action_parser() -> pp.ParserElement:
     def literal_eval(toks):
         return ast.literal_eval(toks[0])
 
-    string = pp.python_quoted_string().set_parse_action(literal_eval)
+    # string = pp.python_quoted_string().set_parse_action(literal_eval)
+    # string = (
+    #     pp.QuotedString(quote_char='"""', esc_char="\\", multiline=True, unquote_results=False).set_parse_action(literal_eval)
+    #     | pp.QuotedString(quote_char="'''", esc_char="\\", multiline=True, unquote_results=False).set_parse_action(literal_eval)
+    #     | pp.QuotedString(quote_char='"', esc_char="\\", multiline=True, unquote_results=False).set_parse_action(literal_eval)
+    #     | pp.QuotedString(quote_char="'", esc_char="\\", multiline=True, unquote_results=False).set_parse_action(literal_eval)
+    # )
+    string = (
+        pp.QuotedString(quote_char='"""', esc_char="\\", multiline=True, unquote_results=True)
+        | pp.QuotedString(quote_char="'''", esc_char="\\", multiline=True, unquote_results=True)
+        | pp.QuotedString(quote_char='"', esc_char="\\", multiline=True, unquote_results=True)
+        | pp.QuotedString(quote_char="'", esc_char="\\", multiline=True, unquote_results=True)
+    )
     number = pp.pyparsing_common.number()
     dict = pp.Forward().set_name("dict")  # will be defined later
     list = pp.Forward().set_name("list")  # will be defined later

--- a/tests/core/test_actions_highlevel.py
+++ b/tests/core/test_actions_highlevel.py
@@ -109,6 +109,21 @@ def test_action_parser():
         NamedArgument(name="y", value={"aaa": 23}),
     ]
 
+def test_action_parser_hash_and_escaped_quotes():
+    """Regression test for issue #296: content containing '#' or escaped quotes
+    inside a string argument was silently dropped by the parser."""
+    parser = highlevel_action_parser
+
+    # A '#' inside a string must not be treated as a comment
+    function_calls = parser.parse_string('send_msg_to_user("text with ## markdown header")', parseAll=True)
+    _, function_args = function_calls[0]
+    assert function_args == ["text with ## markdown header"]
+
+    # Escaped quotes and newlines inside a multiline string must survive
+    msg = 'send_msg_to_user("Lee\'s Market serves \\"specific\\" communities.\n\n## Header\n")'
+    function_calls = parser.parse_string(msg, parseAll=True)
+    _, function_args = function_calls[0]
+    assert function_args == ['Lee\'s Market serves "specific" communities.\n\n## Header\n']
 
 def test_valid_action():
     action_set = HighLevelActionSet()


### PR DESCRIPTION
## Problem
`highlevel_action_parser` silently failed to parse function calls whose 
string arguments contained a `#` character or escaped quotes. For example:

```python
send_msg_to_user("text with ## markdown header")
```

returned `[]` — the entire action was dropped. This happens in practice 
whenever an agent's `send_msg_to_user` message contains markdown headers 
or quoted text.

## Cause
`pp.python_quoted_string()` didn't handle these cases, and the `#` was 
being treated as the start of a Python-style comment.

## Fix
Replaced `python_quoted_string()` with explicit `QuotedString` variants 
(triple-double, triple-single, double, single) with `multiline=True` and 
proper escape handling. This correctly parses embedded `#`, escaped quotes, 
and multiline content.

## Tests
- Existing `test_action_parser` still passes (including the triple-quote case)
- Added `test_action_parser_hash_and_escaped_quotes` regression test

Note: This bug was reported in ServiceNow/AgentLab#296 but lives in 
BrowserGym since `highlevel_action_parser` is defined here. The fix is 
based on the approach suggested by @xhluca in that issue, with a regression 
test added as requested.

Fixes ServiceNow/AgentLab#296