### PR TITLE
fix(miniwob): reject partial find-greatest rewards

### DIFF
--- a/browsergym/miniwob/src/browsergym/miniwob/all.py
+++ b/browsergym/miniwob/src/browsergym/miniwob/all.py
@@ -411,6 +411,7 @@ class EnterTimeTask(AbstractMiniwobTask):
 class FindGreatestTask(AbstractMiniwobTask):
     desc = "Find the card with the greatest number."
     subdomain = "find-greatest"
+    success_threshold = 0.5
 
 
 class FindMidpointTask(AbstractMiniwobTask):

--- a/browsergym/miniwob/src/browsergym/miniwob/base.py
+++ b/browsergym/miniwob/src/browsergym/miniwob/base.py
@@ -13,6 +13,7 @@ class AbstractMiniwobTask(AbstractBrowserTask):
 
     # gym metadata (default value, can be overloaded per task)
     nondeterministic: bool = False
+    success_threshold: float = 0.0
 
     @classmethod
     def get_task_id(cls):
@@ -185,7 +186,7 @@ core.startEpisodeReal();
             return 0, True, "", {"error": "invalid url, terminating task"}
 
         info = self._get_info()
-        reward = float(info["RAW_REWARD_GLOBAL"] > 0)  # TODO: shouldn't it be 0.5?
+        reward = float(info["RAW_REWARD_GLOBAL"] > self.success_threshold)
         done = info["DONE_GLOBAL"]
         msg = ""
         return reward, done, msg, info

--- a/tests/miniwob/test_base.py
+++ b/tests/miniwob/test_base.py
@@ -1,4 +1,6 @@
 import os
+from types import SimpleNamespace
+
 import pytest
 import time
 import gymnasium as gym
@@ -10,6 +12,7 @@ from browsergym.miniwob.all import (
     ClickButtonTask,
     ClickOptionTask,
     DrawLineTask,
+    FindGreatestTask,
     LoginUserTask,
 )
 
@@ -17,6 +20,32 @@ __SLOW_MO = 1000 if "DISPLAY_BROWSER" in os.environ else None
 __HEADLESS = False if "DISPLAY_BROWSER" in os.environ else True
 
 TASKS = [ClickButtonTask, ClickOptionTask, DrawLineTask, LoginUserTask]
+
+
+@pytest.mark.parametrize(
+    ("task_cls", "raw_reward", "expected_reward"),
+    [
+        (FindGreatestTask, 0.1, 0.0),
+        (FindGreatestTask, 1.0, 1.0),
+        (ClickButtonTask, 0.75, 1.0),
+    ],
+)
+def test_validate_respects_task_success_threshold(
+    monkeypatch, task_cls, raw_reward, expected_reward
+):
+    task = task_cls(seed=42, base_url="https://example.test/")
+    page = SimpleNamespace(url=task.url)
+    task.page = page
+    monkeypatch.setattr(
+        task,
+        "_get_info",
+        lambda: {"RAW_REWARD_GLOBAL": raw_reward, "DONE_GLOBAL": True},
+    )
+
+    reward, done, _, _ = task.validate(page, [])
+
+    assert reward == expected_reward
+    assert done is True
 
 
 @pytest.mark.parametrize("task_cls", TASKS)

--- a/tests/miniwob/test_find_greatest.py
+++ b/tests/miniwob/test_find_greatest.py
@@ -1,0 +1,37 @@
+import os
+
+import browsergym.miniwob  # register gym environments
+import gymnasium as gym
+import pytest
+
+__SLOW_MO = 1000 if "DISPLAY_BROWSER" in os.environ else None
+__HEADLESS = False if "DISPLAY_BROWSER" in os.environ else True
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_wrong_card_partial_reward_is_not_success(seed):
+    env = gym.make(
+        "browsergym/miniwob.find-greatest",
+        headless=__HEADLESS,
+        slow_mo=__SLOW_MO,
+        action_mapping=None,
+    )
+
+    try:
+        env.reset(seed=seed)
+        _, reward, terminated, truncated, info = env.step(
+            """
+cards = page.locator(".card")
+values = cards.locator(".card-value").all_text_contents()
+wrong_index = min(range(len(values)), key=lambda index: int(values[index]))
+cards.nth(wrong_index).click()
+page.get_by_role("button", name="Submit").click()
+"""
+        )
+
+        assert info["task_info"]["RAW_REWARD_GLOBAL"] == 0.1
+        assert reward == 0.0
+        assert terminated is True
+        assert truncated is False
+    finally:
+        env.close()


### PR DESCRIPTION
## Summary

- add a task-level MiniWoB success threshold while preserving the existing default
- require `miniwob.find-greatest` to clear its partial wrong-answer reward
- cover the behavior with unit-level and real-browser regressions

## Problem

MiniWoB++ returns a raw reward of `0.1` when `find-greatest` submits the wrong
card and `1.0` for the correct card. BrowserGym currently converts every
positive raw reward to `1.0`, so the wrong-card partial reward is reported as a
successful benchmark episode.

## Changes

`AbstractMiniwobTask` now exposes a `success_threshold` that defaults to `0.0`,
which preserves existing behavior for all other MiniWoB tasks.
`FindGreatestTask` overrides the threshold to `0.5`, separating its known
`0.1` wrong-card reward from its `1.0` success reward.

The regression coverage checks both the threshold conversion directly and a
real `find-greatest` browser episode that deliberately submits the minimum
card.

## Scope and risk

This does not change dependencies, task registration, or the reward behavior
of tasks that do not override the threshold. The only task-specific behavior
change is that `find-greatest` no longer promotes its documented partial
wrong-answer reward to success.

## Verification

```bash
uv run black . --check
uv run pytest tests/miniwob/test_base.py -k success_threshold
MINIWOB_URL=file://<miniwob-plusplus>/miniwob/html/miniwob/ uv run pytest tests/miniwob
```

Results: Black left all 91 files unchanged; the focused regression passed 3
tests; the complete MiniWoB suite passed 43 tests with 4 skipped.

Fixes #392
