### PR TITLE
docs: reference ClawBench as an external benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ BrowserGym includes the following benchmarks by default:
  - [OpenApps](https://facebookresearch.github.io/OpenApps/)
  - [TimeWarp](https://timewarp-web.github.io)
 
+### External related benchmarks
+
+The following independent benchmark is related to BrowserGym's web-agent evaluation scope but is not integrated with or supported by BrowserGym:
+
+* **[ClawBench](https://github.com/reacher-z/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates web and computer-use agents on 283 tasks across 163 live platforms with isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/reacher-z/ClawBench#readme); task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
+
 Designing new web benchmarks with BrowserGym is easy, and simply requires to inherit the [`AbstractBrowserTask`](https://github.com/ServiceNow/BrowserGym/blob/main/browsergym/core/src/browsergym/core/task.py#L7C7-L7C26) class.
 
 ## 🛠️ Setup

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ BrowserGym includes the following benchmarks by default:
 
 The following independent benchmark is related to BrowserGym's web-agent evaluation scope but is not integrated with or supported by BrowserGym:
 
-* **[ClawBench](https://github.com/reacher-z/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates web and computer-use agents on 283 tasks across 163 live platforms with isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/reacher-z/ClawBench#readme); task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
+* **[ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates web and computer-use agents on 283 tasks across 163 live platforms with isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/TIGER-AI-Lab/ClawBench#readme); task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
 
 Designing new web benchmarks with BrowserGym is easy, and simply requires to inherit the [`AbstractBrowserTask`](https://github.com/ServiceNow/BrowserGym/blob/main/browsergym/core/src/browsergym/core/task.py#L7C7-L7C26) class.
 


### PR DESCRIPTION
## Summary

Adds a clearly labeled external benchmark reference immediately after BrowserGym's built-in benchmark list.

The ClawBench entry links its paper, code, project page, and task-definition datasets, and uses neutral wording. It explicitly states that ClawBench is not integrated with or supported by BrowserGym; no BrowserGym benchmark package, task registration, or support claim is added.

## Verification

- Documentation-only change to `README.md`
- `git diff --check` passes
- Submitted by `reacher-z`, a ClawBench maintainer; text prepared with OpenAI Codex assistance
- Maintainer edits are enabled on the fork

No issue is closed by this PR.